### PR TITLE
fixed link to Progamme Committee

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -8,7 +8,7 @@ body_class: projects
 <p class="mt-4"><strong>The project submission period is open!</strong></p>
 <p><a href="https://app.oxfordabstracts.com/stages/5432/submitter" class="button special">Submit your project proposal</a></p>
 <p>The submission period is <strong>Monday 27 February 2023 - Monday 10 April 2023</strong>. Each project can have a maximum of three project leads. </p>
-<p>Project submissions need to cover the following points which will also be used for project review by the <a href="committee.html#programme">BioHackathon Programme Committee</a>:</p>
+<p>Project submissions need to cover the following points which will also be used for project review by the <a href="committees.html#programme">BioHackathon Programme Committee</a>:</p>
 <ul>
 <li><strong>Scope and vision</strong> of your project,</li>
 <li><strong>Alignment with ELIXIR efforts</strong> and beyond,</li>


### PR DESCRIPTION
The link on https://biohackathon-europe.org/projects.html was pointing to committee.html#programme instead of committees.html#programme .