### PR TITLE
Fix social icons in footer.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
            ><i class="fas fa-envelope"></i> <span class="label">Email</span></a></li>
     {% else %}
     <li><a target="_blank" href="{{ socloc[1] }}"
-           ><i class="fab fa-{{socloc[0]}}"></i> <span class="label">{{ socloc[0] }}</span></a></li>
+           ><i class="fab fa-{{socloc[0].lower()}}"></i> <span class="label">{{ socloc[0] }}</span></a></li>
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
            ><i class="fas fa-envelope"></i> <span class="label">Email</span></a></li>
     {% else %}
     <li><a target="_blank" href="{{ socloc[1] }}"
-           ><i class="fab fa-{{socloc[0].lower()}}"></i> <span class="label">{{ socloc[0] }}</span></a></li>
+           ><i class="fab fa-{{socloc[0]|lower}}"></i> <span class="label">{{ socloc[0] }}</span></a></li>
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
            ><i class="fas fa-envelope"></i> <span class="label">Email</span></a></li>
     {% else %}
     <li><a target="_blank" href="{{ socloc[1] }}"
-           ><i class="fab fa-{{socloc[0]|lower}}"></i> <span class="label">{{ socloc[0] }}</span></a></li>
+           ><i class="fab fa-{{socloc[0] | downcase}}"></i> <span class="label">{{ socloc[0] }}</span></a></li>
     {% endif %}
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
- Currently, the social links for GitHub and Twitter are not showing.

![image](https://github.com/elixir-europe/biohackathon-europe-2023/assets/20976111/2c3996f2-06c5-4fc3-8d0a-38ed2ceb847a)

The liquid code needed to be updated to accommodate this by adding downcase.

```html
<i class="fab fa-{{socloc[0] | downcase}}"></i>
```